### PR TITLE
Add AS7331 UV spectral and AMG88XX thermal data to network transmission

### DIFF
--- a/SW_design/PlatformIO_C6/src/network/NetworkTask.cpp
+++ b/SW_design/PlatformIO_C6/src/network/NetworkTask.cpp
@@ -313,6 +313,27 @@ String NetworkTask::formatSensorDataJSON(const SensorData& data) {
         json += "\"spectral_fd\":" + String((int)data.spectral_fd) + ",";
     }
 
+    // Spectral UV data (formatted as integers - ADC counts)
+    if (data.hasSpectralUV()) {
+        json += "\"spectral_uva\":" + String((int)data.spectral_UVA) + ",";
+        json += "\"spectral_uvb\":" + String((int)data.spectral_UVB) + ",";
+        json += "\"spectral_uvc\":" + String((int)data.spectral_UVC) + ",";
+    }
+
+    // Thermal array data (8x8 grid, 64 pixels)
+    if (data.hasThermal()) {
+        json += "\"thermal_pixels\":[";
+        for (int row = 0; row < 8; row++) {
+            for (int col = 0; col < 8; col++) {
+                json += String(data.thermal_pixels[row][col], 1);
+                if (row < 7 || col < 7) {  // Not the last pixel
+                    json += ",";
+                }
+            }
+        }
+        json += "],";
+    }
+
     // Remove trailing comma if present
     if (json.endsWith(",")) {
         json.remove(json.length() - 1);


### PR DESCRIPTION
Extended NetworkTask JSON formatting to include optional sensor data:
- AS7331 UV spectral sensor (spectral_uva, spectral_uvb, spectral_uvc)
- AMG88XX thermal array sensor (thermal_pixels as 64-element flat array)

Both data types are conditionally included using hasSpectralUV() and hasThermal() checks, matching the existing pattern for AS7343 spectral data.

This ensures all initialized sensors have their data transmitted when a network connection is established.